### PR TITLE
Normatiza o código e corrige passagem de valor

### DIFF
--- a/facebook-debug-purge-post.php
+++ b/facebook-debug-purge-post.php
@@ -11,16 +11,16 @@
  */
 
 
-add_action( 'transition_post_status' , 'facebook_purge_future_post', 10, 3);
+add_action( 'transition_post_status' , 'facebook_purge_future_post', 10, 3 );
 
 function facebook_purge_future_post( $new_status, $old_status, $post ) {
-    if($new_status == 'publish') {
-        facebook_purge_debug_cache($post);
+    if ( $new_status == 'publish' ) {
+        facebook_purge_debug_cache( $post->ID );
     }
 }
 // Ping Facebook to recache the URL.
-function facebook_purge_debug_cache($post_id) {
-    $url = get_permalink($post_id);
-    $fb_graph_url = "https://graph.facebook.com/?id=". urlencode($url) ."&scrape=true";
-    $result = wp_remote_post($fb_graph_url);
+function facebook_purge_debug_cache( $post_id ) {
+    $url = get_permalink( $post_id );
+    $fb_graph_url = "https://graph.facebook.com/?id=". urlencode( $url ) ."&scrape=true";
+    $result = wp_remote_post( $fb_graph_url );
 }


### PR DESCRIPTION
O terceiro parâmetro enviado para a função de callback pela action `transition_post_status` é o objeto do post e não o ID, dessa forma para passar o ID é preciso usar `$post->ID`.
